### PR TITLE
Split extensions

### DIFF
--- a/src/main/scala/de/upb/cs/swt/tscs/lambdacalc/LambdaExpression.scala
+++ b/src/main/scala/de/upb/cs/swt/tscs/lambdacalc/LambdaExpression.scala
@@ -1,7 +1,7 @@
 package de.upb.cs.swt.tscs.lambdacalc
 
-import de.upb.cs.swt.tscs.typed.TypeInformations
 import de.upb.cs.swt.tscs.typed.lambdacalc._
+import de.upb.cs.swt.tscs.typed.lambdacalc.extensions.list._
 import de.upb.cs.swt.tscs.{Evaluation, Expression, Value}
 
 /**

--- a/src/main/scala/de/upb/cs/swt/tscs/typed/Typecheck.scala
+++ b/src/main/scala/de/upb/cs/swt/tscs/typed/Typecheck.scala
@@ -2,13 +2,19 @@ package de.upb.cs.swt.tscs.typed
 
 import de.upb.cs.swt.tscs.Expression
 
-import scala.util.Try
+import scala.util.{Success, Try}
 
 /**
   * Basic trait for type checking
   */
 trait Typecheck extends Expression {
-  def typecheck() : Try[_] = typecheck(this)
 
-  def typecheck(expr : Expression) : Try[_]
+  def storeAndWrap(e: Expression, t: TypeInformation, gamma: scala.collection.mutable.HashMap[Expression, TypeInformation]): Try[TypeInformation] = {
+    gamma.put(e, t)
+    Success(t)
+  }
+
+  def typecheck() : Try[_] = typecheck(this, scala.collection.mutable.HashMap())
+
+  def typecheck(expr : Expression, gamma: scala.collection.mutable.HashMap[Expression, TypeInformation]) : Try[_]
 }

--- a/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/TypedLambdaCalculusSyntax.scala
+++ b/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/TypedLambdaCalculusSyntax.scala
@@ -2,72 +2,15 @@ package de.upb.cs.swt.tscs.typed.lambdacalc
 
 
 import de.upb.cs.swt.tscs.lambdacalc._
-import de.upb.cs.swt.tscs.typed.{BaseTypeInformation, FunctionTypeInformation, ListTypeInformation, TypeInformation}
-import org.parboiled2.{CharPredicate, Parser, ParserInput, Rule1}
+import de.upb.cs.swt.tscs.typed.lambdacalc.extensions.list._
+import org.parboiled2.ParserInput
 
 /**
-  * A syntax definition for the typed λ calculus
+  * A syntax definition for the typed λ calculus. The different syntax extensions are mixed in as traits to keep them
+  * as separate as possible.
   */
-class TypedLambdaCalculusSyntax(input : ParserInput) extends LambdaCalculusSyntax(input) {
+class TypedLambdaCalculusSyntax(input : ParserInput) extends LambdaCalculusSyntax(input)
+with ListSyntax
+{
 
-  override def Term: Rule1[TypedLambdaExpression] = rule {
-      LambdaAbstractionTerm ~> (widen(_ : LambdaAbstraction)) |
-      LambdaApplicationTerm ~> (widen(_ : LambdaApplication)) |
-      NilTerm | HeadTerm | TailTerm | ConsTerm | IsNilTerm |
-      LambdaVariableTerm
-  }
-
-  override def LambdaVariableTerm : Rule1[TypedLambdaVariable] = rule {
-    capture(oneOrMore(CharPredicate.Alpha)) ~ optional (" : " ~ TypeInfo) ~> TypedLambdaVariable
-  }
-
-  def IsNilTerm: Rule1[TypedLambdaExpression] = rule {
-    "isnil[" ~ TypeInfo ~ "] " ~ Term ~> IsNil
-  }
-
-  def NilTerm: Rule1[TypedLambdaExpression] = rule {
-    "nil[" ~ TypeInfo ~ "]" ~> NilList
-  }
-
-  def HeadTerm: Rule1[TypedLambdaExpression] = rule {
-    "head[" ~ TypeInfo ~ "] " ~ Term ~> Head
-  }
-
-  def TailTerm: Rule1[TypedLambdaExpression] = rule {
-    "tail[" ~ TypeInfo ~ "] " ~ Term ~> Tail
-  }
-
-  def ConsTerm: Rule1[TypedLambdaExpression] = rule {
-    "cons[" ~ TypeInfo ~ "] " ~ Term ~ " " ~ Term ~> ConsTermExpression
-  }
-
-
-  def TypeInfo = rule {
-    BaseTypeInfo | BoolTypeInfo | FunctionType | ListTypeInfo
-  }
-
-  def ListTypeInfo : Rule1[TypeInformation] = rule {
-    "List " ~ TypeInfo ~> ListTypeInformation
-  }
-
-  def BaseTypeInfo : Rule1[TypeInformation] = rule {
-    capture("A") ~> BaseTypeInformation
-  }
-
-  def BoolTypeInfo : Rule1[TypeInformation] = rule {
-    capture("Bool") ~> BaseTypeInformation
-  }
-
-  def FunctionType : Rule1[TypeInformation] = rule {
-    "[" ~ TypeInfo ~ "->" ~ TypeInfo ~ "]" ~> FunctionTypeInformation
-  }
-
-
-  def widen(expression: LambdaExpression) : TypedLambdaExpression = {
-    expression match {
-      case UntypedLambdaVariable(v) => new TypedLambdaVariable(v, Option.empty)
-      case LambdaApplication(f,a) => new LambdaApplication(f,a) with TypedLambdaExpression
-      case LambdaAbstraction(v,t) => new LambdaAbstraction(v,t) with TypedLambdaExpression
-    }
-  }
 }

--- a/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/TypedLambdaExpression.scala
+++ b/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/TypedLambdaExpression.scala
@@ -2,6 +2,7 @@ package de.upb.cs.swt.tscs.typed.lambdacalc
 
 import de.upb.cs.swt.tscs.lambdacalc.{LambdaAbstraction, LambdaApplication, LambdaExpression, UntypedLambdaVariable}
 import de.upb.cs.swt.tscs.typed._
+import de.upb.cs.swt.tscs.typed.lambdacalc.extensions.list._
 import de.upb.cs.swt.tscs.{Evaluation, Expression}
 
 import scala.util.{Failure, Success, Try}

--- a/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/TypedLambdaExpression.scala
+++ b/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/TypedLambdaExpression.scala
@@ -39,21 +39,16 @@ trait TypedLambdaExpression extends LambdaExpression with Typecheck {
       case n: NilList => storeAndWrap(n, new ListTypeInformation(n.typeInfo))
 
       /* T-Cons */
-      case cons: ConsTermExpression if typecheck(cons.t1).isSuccess && typecheck(cons.t1).get == cons.typeInfo
-        && typecheck(cons.t2).isSuccess && typecheck(cons.t2).get.isInstanceOf[ListTypeInformation] &&
-        typecheck(cons.t2).get.asInstanceOf[ListTypeInformation].listType == cons.typeInfo
+      case cons: ConsTermExpression if T_Cons_Premise(cons)
       => storeAndWrap(cons, new ListTypeInformation(cons.typeInfo))
       /*T-IsNil */
-      case isNil: IsNil if typecheck(isNil.t1).isSuccess && typecheck(isNil.t1).get.isInstanceOf[ListTypeInformation]
-        && typecheck(isNil.t1).get.asInstanceOf[ListTypeInformation].listType == isNil.typeInfo
+      case isNil: IsNil if T_IsNil_Premise(isNil)
       => storeAndWrap(isNil, TypeInformations.Bool)
       /*T-Head */
-      case head: Head if typecheck(head.t1).isSuccess && typecheck(head.t1).get.isInstanceOf[ListTypeInformation]
-        && typecheck(head.t1).get.asInstanceOf[ListTypeInformation].listType == head.typeInfo
+      case head: Head if T_Head_Premise(head)
       => storeAndWrap(head, head.typeInfo)
       /*T-Tail */
-      case tail: Tail if typecheck(tail.t1).isSuccess && typecheck(tail.t1).get.isInstanceOf[ListTypeInformation]
-        && typecheck(tail.t1).get.asInstanceOf[ListTypeInformation].listType == tail.typeInfo
+      case tail: Tail if T_Tail_Premise(tail)
       => storeAndWrap(tail, new ListTypeInformation(tail.typeInfo))
 
 
@@ -87,6 +82,30 @@ trait TypedLambdaExpression extends LambdaExpression with Typecheck {
     result
   }
 
+
+  private def T_Tail_Premise(tail: Tail) =
+    typecheck(tail.t1) match {
+      case Success(t1: ListTypeInformation) => t1.listType == tail.typeInfo
+      case _ => false
+    }
+
+  private def T_Head_Premise(head: Head) =
+    typecheck(head.t1) match {
+      case Success(t1: ListTypeInformation) => t1.listType == head.typeInfo
+      case _ => false
+    }
+
+  private def T_IsNil_Premise(isNil: IsNil) =
+    typecheck(isNil.t1) match {
+      case Success(t1: ListTypeInformation) => t1.listType == isNil.typeInfo
+      case _ => false
+    }
+
+  private def T_Cons_Premise(cons: ConsTermExpression) =
+    (typecheck(cons.t1), typecheck(cons.t2)) match {
+      case (Success(t1), Success(t2: ListTypeInformation)) => t1 == cons.typeInfo && t2.listType == cons.typeInfo
+      case _ => false
+    }
 
   private def T_False_Premise(v: TypedLambdaVariable) =
     v.variable == "false" &&

--- a/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/basetyped/BasicTypeSyntax.scala
+++ b/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/basetyped/BasicTypeSyntax.scala
@@ -1,0 +1,48 @@
+package de.upb.cs.swt.tscs.typed.lambdacalc.extensions.basetyped
+
+import de.upb.cs.swt.tscs.lambdacalc._
+import de.upb.cs.swt.tscs.typed.{BaseTypeInformation, FunctionTypeInformation, TypeInformation}
+import de.upb.cs.swt.tscs.typed.lambdacalc.{TypedLambdaExpression, TypedLambdaVariable}
+import org.parboiled2.{CharPredicate, Rule1}
+
+/**
+  * Syntax definition for basic types. Was extracted to own file because [[de.upb.cs.swt.tscs.typed.lambdacalc.extensions.list.ListSyntax]]
+  * needs basic types and extends on them.
+  */
+trait BasicTypeSyntax extends LambdaCalculusSyntax{
+
+  override def Term: Rule1[TypedLambdaExpression] = rule {
+    LambdaAbstractionTerm ~> (widen(_ : LambdaAbstraction)) |
+      LambdaApplicationTerm ~> (widen(_ : LambdaApplication)) |
+      LambdaVariableTerm
+  }
+
+  override def LambdaVariableTerm : Rule1[TypedLambdaVariable] = rule {
+    capture(oneOrMore(CharPredicate.Alpha)) ~ optional (" : " ~ TypeInfo) ~> TypedLambdaVariable
+  }
+
+  def TypeInfo = rule {
+    BaseTypeInfo | BoolTypeInfo | FunctionType
+  }
+
+  def BaseTypeInfo : Rule1[TypeInformation] = rule {
+    capture("A") ~> BaseTypeInformation
+  }
+
+  def BoolTypeInfo : Rule1[TypeInformation] = rule {
+    capture("Bool") ~> BaseTypeInformation
+  }
+
+  def FunctionType : Rule1[TypeInformation] = rule {
+    "[" ~ TypeInfo ~ "->" ~ TypeInfo ~ "]" ~> FunctionTypeInformation
+  }
+
+
+  def widen(expression: LambdaExpression) : TypedLambdaExpression = {
+    expression match {
+      case UntypedLambdaVariable(v) => new TypedLambdaVariable(v, Option.empty)
+      case LambdaApplication(f,a) => new LambdaApplication(f,a) with TypedLambdaExpression
+      case LambdaAbstraction(v,t) => new LambdaAbstraction(v,t) with TypedLambdaExpression
+    }
+  }
+}

--- a/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/ConsTermExpression.scala
+++ b/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/ConsTermExpression.scala
@@ -1,8 +1,8 @@
-package de.upb.cs.swt.tscs.typed.lambdacalc
+package de.upb.cs.swt.tscs.typed.lambdacalc.extensions.list
 
-import de.upb.cs.swt.tscs.{Expression, Value}
-import de.upb.cs.swt.tscs.lambdacalc.LambdaExpression
+import de.upb.cs.swt.tscs.Expression
 import de.upb.cs.swt.tscs.typed.TypeInformation
+import de.upb.cs.swt.tscs.typed.lambdacalc.TypedLambdaExpression
 
 /**
   * Represents a cons with terns in the λ calculus

--- a/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/ConsTermExpression.scala
+++ b/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/ConsTermExpression.scala
@@ -7,7 +7,7 @@ import de.upb.cs.swt.tscs.typed.lambdacalc.TypedLambdaExpression
 /**
   * Represents a cons with terns in the λ calculus
   */
-case class ConsTermExpression(typeInfo: TypeInformation, t1: Expression, t2: Expression) extends Expression with TypedLambdaExpression {
+case class ConsTermExpression(typeInfo: TypeInformation, t1: Expression, t2: Expression) extends ListExpression with TypedLambdaExpression {
   override def toString: String = "cons[" + typeInfo + "] " + t1.toString + " " + t2.toString
 
 }

--- a/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/ConsValueExpression.scala
+++ b/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/ConsValueExpression.scala
@@ -8,4 +8,5 @@ import de.upb.cs.swt.tscs.typed.lambdacalc.TypedLambdaExpression
   * Represents a cons with values in the λ calculus
   */
 case class ConsValueExpression(typeInfo: TypeInformation, v1: Value, v2: Value)
-  extends Value("cons[" + typeInfo.toString + "] " + v1 + " " + v2)  with TypedLambdaExpression
+  extends Value("cons[" + typeInfo.toString + "] " + v1 + " " + v2)
+    with TypedLambdaExpression with ListExpression

--- a/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/ConsValueExpression.scala
+++ b/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/ConsValueExpression.scala
@@ -1,8 +1,8 @@
-package de.upb.cs.swt.tscs.typed.lambdacalc
+package de.upb.cs.swt.tscs.typed.lambdacalc.extensions.list
 
-import de.upb.cs.swt.tscs.{Expression, Value}
-import de.upb.cs.swt.tscs.lambdacalc.LambdaExpression
+import de.upb.cs.swt.tscs.Value
 import de.upb.cs.swt.tscs.typed.TypeInformation
+import de.upb.cs.swt.tscs.typed.lambdacalc.TypedLambdaExpression
 
 /**
   * Represents a cons with values in the λ calculus

--- a/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/Head.scala
+++ b/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/Head.scala
@@ -1,8 +1,8 @@
-package de.upb.cs.swt.tscs.typed.lambdacalc
+package de.upb.cs.swt.tscs.typed.lambdacalc.extensions.list
 
 import de.upb.cs.swt.tscs.Expression
-import de.upb.cs.swt.tscs.lambdacalc.LambdaExpression
 import de.upb.cs.swt.tscs.typed.TypeInformation
+import de.upb.cs.swt.tscs.typed.lambdacalc.TypedLambdaExpression
 
 /**
   * Represents a head term in the λ calculus

--- a/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/Head.scala
+++ b/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/Head.scala
@@ -7,6 +7,6 @@ import de.upb.cs.swt.tscs.typed.lambdacalc.TypedLambdaExpression
 /**
   * Represents a head term in the λ calculus
   */
-case class Head(typeInfo: TypeInformation, t1: Expression) extends Expression with TypedLambdaExpression {
+case class Head(typeInfo: TypeInformation, t1: Expression) extends ListExpression with TypedLambdaExpression {
   override def toString: String = "head[" + typeInfo + "] " + t1.toString
 }

--- a/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/IsNil.scala
+++ b/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/IsNil.scala
@@ -1,8 +1,8 @@
-package de.upb.cs.swt.tscs.typed.lambdacalc
+package de.upb.cs.swt.tscs.typed.lambdacalc.extensions.list
 
 import de.upb.cs.swt.tscs.Expression
-import de.upb.cs.swt.tscs.lambdacalc.LambdaExpression
 import de.upb.cs.swt.tscs.typed.TypeInformation
+import de.upb.cs.swt.tscs.typed.lambdacalc.TypedLambdaExpression
 
 /**
   * Represents a isnil term in the λ calculus

--- a/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/IsNil.scala
+++ b/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/IsNil.scala
@@ -7,6 +7,6 @@ import de.upb.cs.swt.tscs.typed.lambdacalc.TypedLambdaExpression
 /**
   * Represents a isnil term in the λ calculus
   */
-case class IsNil(typeInfo: TypeInformation, t1: Expression) extends Expression with TypedLambdaExpression {
+case class IsNil(typeInfo: TypeInformation, t1: Expression) extends ListExpression with TypedLambdaExpression {
   override def toString: String = "isnil[" + typeInfo + "] " + t1.toString
 }

--- a/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/ListExpression.scala
+++ b/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/ListExpression.scala
@@ -1,0 +1,5 @@
+package de.upb.cs.swt.tscs.typed.lambdacalc.extensions.list
+
+import de.upb.cs.swt.tscs.Expression
+
+trait ListExpression extends Expression

--- a/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/ListExpression.scala
+++ b/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/ListExpression.scala
@@ -2,4 +2,4 @@ package de.upb.cs.swt.tscs.typed.lambdacalc.extensions.list
 
 import de.upb.cs.swt.tscs.Expression
 
-trait ListExpression extends Expression
+trait ListExpression extends Expression with ListTypeCheck

--- a/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/ListSyntax.scala
+++ b/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/ListSyntax.scala
@@ -1,0 +1,34 @@
+package de.upb.cs.swt.tscs.typed.lambdacalc.extensions.list
+
+import de.upb.cs.swt.tscs.typed.lambdacalc.TypedLambdaExpression
+import de.upb.cs.swt.tscs.typed.lambdacalc.extensions.basetyped.BasicTypeSyntax
+import org.parboiled2.Rule1
+
+trait ListSyntax extends BasicTypeSyntax {
+
+  override def Term: Rule1[TypedLambdaExpression] = rule {
+      NilTerm | HeadTerm | TailTerm | ConsTerm | IsNilTerm |
+      super.Term
+  }
+
+  def IsNilTerm: Rule1[TypedLambdaExpression] = rule {
+    "isnil[" ~ TypeInfo ~ "] " ~ Term ~> IsNil
+  }
+
+  def NilTerm: Rule1[TypedLambdaExpression] = rule {
+    "nil[" ~ TypeInfo ~ "]" ~> NilList
+  }
+
+  def HeadTerm: Rule1[TypedLambdaExpression] = rule {
+    "head[" ~ TypeInfo ~ "] " ~ Term ~> Head
+  }
+
+  def TailTerm: Rule1[TypedLambdaExpression] = rule {
+    "tail[" ~ TypeInfo ~ "] " ~ Term ~> Tail
+  }
+
+  def ConsTerm: Rule1[TypedLambdaExpression] = rule {
+    "cons[" ~ TypeInfo ~ "] " ~ Term ~ " " ~ Term ~> ConsTermExpression
+  }
+
+}

--- a/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/ListTypeCheck.scala
+++ b/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/ListTypeCheck.scala
@@ -1,0 +1,67 @@
+package de.upb.cs.swt.tscs.typed.lambdacalc.extensions.list
+
+import de.upb.cs.swt.tscs.Expression
+import de.upb.cs.swt.tscs.typed._
+
+import scala.util.{Failure, Success, Try}
+
+trait ListTypeCheck extends Typecheck{
+  override def typecheck(): Try[_] = typecheck(this,scala.collection.mutable.HashMap())
+  override def typecheck(expr: Expression, gamma: scala.collection.mutable.HashMap[Expression, TypeInformation]): Try[TypeInformation] = {
+    // Just an optimization
+    if (gamma.contains(expr)) return Success(gamma(expr))
+
+    val result = expr match {
+      /* T-Nil */
+      case n: NilList => storeAndWrap(n, ListTypeInformation(n.typeInfo), gamma)
+
+      /* T-Cons */
+      case cons: ConsTermExpression if T_Cons_Premise(cons, gamma)
+      => storeAndWrap(cons, ListTypeInformation(cons.typeInfo), gamma)
+      /*T-IsNil */
+      case isNil: IsNil if T_IsNil_Premise(isNil, gamma)
+      => storeAndWrap(isNil, TypeInformations.Bool, gamma)
+      /*T-Head */
+      case head: Head if T_Head_Premise(head, gamma)
+      => storeAndWrap(head, head.typeInfo, gamma)
+      /*T-Tail */
+      case tail: Tail if T_Tail_Premise(tail, gamma)
+      => storeAndWrap(tail, ListTypeInformation(tail.typeInfo), gamma)
+
+      case _
+      => Failure[TypeInformation](new TypingException(expr))
+    }
+    /*
+    print(expr.toString + " --- ")
+    println(result match {
+      case Success(t) => "Successfully typed to " + t
+      case Failure(e) => "Typing failed"
+    })*/
+    result
+  }
+
+
+  private def T_Tail_Premise(tail: Tail, gamma: scala.collection.mutable.HashMap[Expression, TypeInformation]) =
+    typecheck(tail.t1, gamma) match {
+      case Success(t1: ListTypeInformation) => t1.listType == tail.typeInfo
+      case _ => false
+    }
+
+  private def T_Head_Premise(head: Head, gamma: scala.collection.mutable.HashMap[Expression, TypeInformation]) =
+    typecheck(head.t1, gamma) match {
+      case Success(t1: ListTypeInformation) => t1.listType == head.typeInfo
+      case _ => false
+    }
+
+  private def T_IsNil_Premise(isNil: IsNil, gamma: scala.collection.mutable.HashMap[Expression, TypeInformation]) =
+    typecheck(isNil.t1, gamma) match {
+      case Success(t1: ListTypeInformation) => t1.listType == isNil.typeInfo
+      case _ => false
+    }
+
+  private def T_Cons_Premise(cons: ConsTermExpression, gamma: scala.collection.mutable.HashMap[Expression, TypeInformation]) =
+    (typecheck(cons.t1, gamma), typecheck(cons.t2, gamma)) match {
+      case (Success(t1), Success(t2: ListTypeInformation)) => t1 == cons.typeInfo && t2.listType == cons.typeInfo
+      case _ => false
+    }
+}

--- a/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/NilList.scala
+++ b/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/NilList.scala
@@ -7,4 +7,5 @@ import de.upb.cs.swt.tscs.typed.lambdacalc.TypedLambdaExpression
 /**
   * Represents an nil list in the λ calculus
   */
-case class NilList(typeInfo: TypeInformation) extends Value("nil[" + typeInfo + "]") with TypedLambdaExpression
+case class NilList(typeInfo: TypeInformation) extends Value("nil[" + typeInfo + "]")
+  with TypedLambdaExpression with ListExpression

--- a/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/NilList.scala
+++ b/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/NilList.scala
@@ -1,8 +1,8 @@
-package de.upb.cs.swt.tscs.typed.lambdacalc
+package de.upb.cs.swt.tscs.typed.lambdacalc.extensions.list
 
 import de.upb.cs.swt.tscs.Value
-import de.upb.cs.swt.tscs.lambdacalc.LambdaExpression
 import de.upb.cs.swt.tscs.typed.TypeInformation
+import de.upb.cs.swt.tscs.typed.lambdacalc.TypedLambdaExpression
 
 /**
   * Represents an nil list in the λ calculus

--- a/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/Tail.scala
+++ b/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/Tail.scala
@@ -7,6 +7,6 @@ import de.upb.cs.swt.tscs.typed.lambdacalc.TypedLambdaExpression
 /**
   * Represents a tail term in the λ calculus
   */
-case class Tail(typeInfo: TypeInformation, t1: Expression) extends Expression with TypedLambdaExpression {
+case class Tail(typeInfo: TypeInformation, t1: Expression) extends ListExpression with TypedLambdaExpression {
   override def toString: String = "tail[" + typeInfo + "] " + t1.toString
 }

--- a/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/Tail.scala
+++ b/src/main/scala/de/upb/cs/swt/tscs/typed/lambdacalc/extensions/list/Tail.scala
@@ -1,8 +1,8 @@
-package de.upb.cs.swt.tscs.typed.lambdacalc
+package de.upb.cs.swt.tscs.typed.lambdacalc.extensions.list
 
 import de.upb.cs.swt.tscs.Expression
-import de.upb.cs.swt.tscs.lambdacalc.LambdaExpression
 import de.upb.cs.swt.tscs.typed.TypeInformation
+import de.upb.cs.swt.tscs.typed.lambdacalc.TypedLambdaExpression
 
 /**
   * Represents a tail term in the λ calculus

--- a/src/main/scala/de/upb/cs/swt/tscs/typed/numexpr/TypedNumericExpression.scala
+++ b/src/main/scala/de/upb/cs/swt/tscs/typed/numexpr/TypedNumericExpression.scala
@@ -15,7 +15,7 @@ trait TypedNumericExpression extends NumericExpression with Typecheck {
 
   val Gamma = new scala.collection.mutable.HashMap[Expression, TypeInformation]
 
-  override def typecheck(expr: Expression): Try[TypeInformation] = {
+  override def typecheck(expr: Expression, gamma: scala.collection.mutable.HashMap[Expression, TypeInformation] = scala.collection.mutable.HashMap()): Try[TypeInformation] = {
     expr match {
       /* T-True */
       case e: ValueExpr


### PR DESCRIPTION
Splits existing extensions to simplify the adding of new ones without conflicts. Also extracts the `T-somethings` to their own methods with pattern matching to improve readability a bit.